### PR TITLE
add impersonation to use , and metadata to user and org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propelauth/cloudflare-worker",
-  "version": "v2.0.0",
+  "version": "v2.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@propelauth/cloudflare-worker",
-      "version": "v2.0.0",
+      "version": "v2.0.7",
       "license": "MIT",
       "dependencies": {
         "jose": "^4.11.2"

--- a/src/api.ts
+++ b/src/api.ts
@@ -262,6 +262,7 @@ export type UpdateUserMetadataRequest = {
     firstName?: string,
     lastName?: string,
     pictureUrl?: string
+    metadata?: {[key: string]: any }
 }
 
 export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
@@ -274,6 +275,7 @@ export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string,
         first_name: updateUserMetadataRequest.firstName,
         last_name: updateUserMetadataRequest.lastName,
         picture_url: updateUserMetadataRequest.pictureUrl,
+        metadata: updateUserMetadataRequest.metadata,
     }
     return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
@@ -651,6 +653,7 @@ export type UpdateOrgRequest = {
     orgId: string
     name?: string
     canSetupSaml?: boolean
+    metadata: {[key: string]: any},
 }
 
 export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
@@ -661,6 +664,7 @@ export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: Update
     const request = {
         name: updateOrgRequest.name,
         can_setup_saml: updateOrgRequest.canSetupSaml,
+        metadata: updateOrgRequest.metadata,
     }
     return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${updateOrgRequest.orgId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
@@ -773,6 +777,10 @@ function parseUser(response: string) {
             this.legacyUserId = value
         } else if (key === "org_id_to_org_info") {
             this.orgIdToOrgInfo = value;
+        } else if (key === "impersonated_user_id") {
+            this.impersonatorUserId = value;
+        } else if (key === "metadata") {
+            this.metadata = value;
         } else {
             return value
         }

--- a/src/user.ts
+++ b/src/user.ts
@@ -5,7 +5,10 @@ export type User = {
     // If you used our migration APIs to migrate this user from a different system,
     //   this is their original ID from that system.
     legacyUserId?: string
+    impersonatorUserId?: string
+    metadata?: {[key: string]: any}
 }
+
 export type Org = {
     orgId: string,
     name: string,
@@ -34,20 +37,24 @@ export type UserMetadata = {
     // If you used our migration APIs to migrate this user from a different system,
     //   this is their original ID from that system.
     legacyUserId?: string
+    impersonatorUserId?: string
+    metadata?: {[key: string]: any}
 }
 
 export class OrgMemberInfo {
     public orgId: string
     public orgName: string
+    public orgMetadata: {[key: string]: any}
     public urlSafeOrgName: string
 
     private userAssignedRole: string
     private userInheritedRolesPlusCurrentRole: string[]
     private userPermissions: string[]
 
-    constructor(orgId: string, orgName: string, urlSafeOrgName: string, userAssignedRole: string, userInheritedRolesPlusCurrentRole: string[], userPermissions: string[]) {
+    constructor(orgId: string, orgName: string, orgMetadata: {[key: string]: any}, urlSafeOrgName: string, userAssignedRole: string, userInheritedRolesPlusCurrentRole: string[], userPermissions: string[]) {
         this.orgId = orgId
         this.orgName = orgName
+        this.orgMetadata = orgMetadata
         this.urlSafeOrgName = urlSafeOrgName
 
         this.userAssignedRole = userAssignedRole
@@ -102,6 +109,7 @@ export type OrgIdToOrgMemberInfo = {
 export type InternalOrgMemberInfo = {
     org_id: string
     org_name: string
+    org_metadata: {[key: string]: any}
     url_safe_org_name: string
     user_role: string
     inherited_user_roles_plus_current_role: string[]
@@ -113,6 +121,8 @@ export type InternalUser = {
 
     // If you used our migration APIs to migrate this user from a different system, this is their original ID from that system.
     legacy_user_id?: string
+    impersonatorUserId?: string
+    metadata?: {[key: string]: any}
 }
 
 export function toUser(snake_case: InternalUser): User {
@@ -120,6 +130,8 @@ export function toUser(snake_case: InternalUser): User {
         userId: snake_case.user_id,
         orgIdToOrgMemberInfo: toOrgIdToOrgMemberInfo(snake_case.org_id_to_org_member_info),
         legacyUserId: snake_case.legacy_user_id,
+        impersonatorUserId: snake_case.impersonatorUserId,
+        metadata: snake_case.metadata,
     }
 }
 
@@ -137,6 +149,7 @@ export function toOrgIdToOrgMemberInfo(snake_case?: {
             camelCase[key] = new OrgMemberInfo(
                 snakeCaseValue.org_id,
                 snakeCaseValue.org_name,
+                snakeCaseValue.org_metadata,
                 snakeCaseValue.url_safe_org_name,
                 snakeCaseValue.user_role,
                 snakeCaseValue.inherited_user_roles_plus_current_role,

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -104,6 +104,7 @@ test("toUser converts correctly with orgs", async () => {
             "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a": {
                 org_id: "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a",
                 org_name: "orgA",
+                org_metadata: {"orgdata_a": "orgvalue_a"},
                 url_safe_org_name: "orga",
                 user_role: "Owner",
                 inherited_user_roles_plus_current_role: ["Owner", "Admin", "Member"],
@@ -112,6 +113,7 @@ test("toUser converts correctly with orgs", async () => {
             "4ca20d17-5021-4d62-8b3d-148214fa8d6d": {
                 org_id: "4ca20d17-5021-4d62-8b3d-148214fa8d6d",
                 org_name: "orgB",
+                org_metadata: {"orgdata_b": "orgvalue_b"},
                 url_safe_org_name: "orgb",
                 user_role: "Admin",
                 inherited_user_roles_plus_current_role: ["Admin", "Member"],
@@ -120,6 +122,7 @@ test("toUser converts correctly with orgs", async () => {
             "15a31d0c-d284-4e7b-80a2-afb23f939cc3": {
                 org_id: "15a31d0c-d284-4e7b-80a2-afb23f939cc3",
                 org_name: "orgC",
+                org_metadata: {"orgdata_c": "orgvalue_c"},
                 url_safe_org_name: "orgc",
                 user_role: "Member",
                 inherited_user_roles_plus_current_role: ["Member"],
@@ -134,6 +137,7 @@ test("toUser converts correctly with orgs", async () => {
             "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a": new OrgMemberInfo(
                 "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a",
                 "orgA",
+                {"orgdata_a": "orgvalue_a"},
                 "orga",
                 "Owner",
                 ["Owner", "Admin", "Member"],
@@ -142,6 +146,7 @@ test("toUser converts correctly with orgs", async () => {
             "4ca20d17-5021-4d62-8b3d-148214fa8d6d": new OrgMemberInfo(
                 "4ca20d17-5021-4d62-8b3d-148214fa8d6d",
                 "orgB",
+                {"orgdata_b": "orgvalue_b"},
                 "orgb",
                 "Admin",
                 ["Admin", "Member"],
@@ -150,6 +155,7 @@ test("toUser converts correctly with orgs", async () => {
             "15a31d0c-d284-4e7b-80a2-afb23f939cc3": new OrgMemberInfo(
                 "15a31d0c-d284-4e7b-80a2-afb23f939cc3",
                 "orgC",
+                {"orgdata_c": "orgvalue_c"},
                 "orgc",
                 "Member",
                 ["Member"],
@@ -239,6 +245,9 @@ test("validateAccessTokenAndGetUserWithOrgInfoWithMinimumRole works with miniumu
         org_id_to_org_member_info: {
             [orgMemberInfo.org_id]: orgMemberInfo,
         },
+        metadata: {
+            "userdata": "uservalue",
+        }
     }
     const orgInfo: RequiredOrgInfo = {
         orgId: orgMemberInfo.org_id,
@@ -435,6 +444,7 @@ function randomOrg(): InternalOrgMemberInfo {
     return {
         org_id: uuid(),
         org_name: randomString(),
+        org_metadata: {"internalData": randomString()},
         url_safe_org_name: urlSafeOrgName,
         user_role: "Admin",
         inherited_user_roles_plus_current_role: ["Admin", "Member"],


### PR DESCRIPTION
The User now has an "impersonatorUserId" field. This is the UUID of the other user that is impersonating this user. It will be None if impersonation is not happening (which it normally isn't).

The User objects also have a "metadata" field, which is private, user-specific metadata which can be set via the regular update_metadata endpoint. The user will never see or use this metadata, it's just for the PropelAuth customer.

The Org objects have an "orgMetadata" field. Much like user metadata, this is a private field.

The metadata objects are simple hashes with a string key and any JSON object for the value.