### PR TITLE
Add legacy user metadata

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -1,7 +1,10 @@
 export type User = {
     userId: string
     orgIdToOrgMemberInfo?: OrgIdToOrgMemberInfo
-
+    email: string
+    firstName?: string,
+    lastName?: string,
+    username?: string,
     // If you used our migration APIs to migrate this user from a different system,
     //   this is their original ID from that system.
     legacyUserId?: string
@@ -118,7 +121,10 @@ export type InternalOrgMemberInfo = {
 export type InternalUser = {
     user_id: string
     org_id_to_org_member_info?: { [org_id: string]: InternalOrgMemberInfo }
-
+    email: string
+    first_name?: string,
+    last_name?: string,
+    username?: string,
     // If you used our migration APIs to migrate this user from a different system, this is their original ID from that system.
     legacy_user_id?: string
     impersonatorUserId?: string
@@ -129,6 +135,10 @@ export function toUser(snake_case: InternalUser): User {
     return {
         userId: snake_case.user_id,
         orgIdToOrgMemberInfo: toOrgIdToOrgMemberInfo(snake_case.org_id_to_org_member_info),
+        email: snake_case.email,
+        firstName: snake_case.first_name,
+        lastName: snake_case.last_name,
+        username: snake_case.username,
         legacyUserId: snake_case.legacy_user_id,
         impersonatorUserId: snake_case.impersonatorUserId,
         metadata: snake_case.metadata,

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -100,6 +100,8 @@ test("validateAccessTokenAndGetUser fails with incorrect issuer", async () => {
 test("toUser converts correctly with orgs", async () => {
     const internalUser: InternalUser = {
         user_id: "cbf064e2-edaa-4d35-b413-a8d857329c12",
+        email: "easteregg@propelauth.com",
+        first_name: "Easter",
         org_id_to_org_member_info: {
             "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a": {
                 org_id: "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a",
@@ -133,6 +135,8 @@ test("toUser converts correctly with orgs", async () => {
 
     const user: User = {
         userId: "cbf064e2-edaa-4d35-b413-a8d857329c12",
+        email: "easteregg@propelauth.com",
+        firstName: "Easter",
         orgIdToOrgMemberInfo: {
             "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a": new OrgMemberInfo(
                 "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a",
@@ -171,10 +175,21 @@ test("toUser converts correctly without orgs", async () => {
     const internalUser: InternalUser = {
         user_id: "cbf064e2-edaa-4d35-b413-a8d857329c12",
         legacy_user_id: "something",
+        email: "easteregg@propelauth.com",
+        first_name: "Easter",
+        last_name: "Egg",
+        username: "easteregg",
+        metadata: {"key": "value"},
+
     }
     const user: User = {
         userId: "cbf064e2-edaa-4d35-b413-a8d857329c12",
         legacyUserId: "something",
+        email: "easteregg@propelauth.com",
+        firstName: "Easter",
+        lastName: "Egg",
+        username: "easteregg",
+        metadata: {"key": "value"},
     }
     expect(toUser(internalUser)).toEqual(user)
 })
@@ -186,6 +201,7 @@ test("validateAuthHeaderAndGetUserWithOrgInfo get user and org for extracted org
     const orgMemberInfo = randomOrg()
     const internalUser: InternalUser = {
         user_id: uuid(),
+        email: "easteregg@propelauth.com",
         org_id_to_org_member_info: {
             [orgMemberInfo.org_id]: orgMemberInfo,
         },
@@ -209,6 +225,7 @@ test("validateAuthHeaderAndGetUserWithOrgInfo fails for valid access token but u
 
     const internalUser: InternalUser = {
         user_id: uuid(),
+        email: "easteregg@propelauth.com",
     }
     const orgInfo: RequiredOrgInfo = {
         orgId: uuid(),
@@ -242,6 +259,7 @@ test("validateAccessTokenAndGetUserWithOrgInfoWithMinimumRole works with miniumu
     const orgMemberInfo = randomOrg()
     const internalUser: InternalUser = {
         user_id: uuid(),
+        email: "easteregg@propelauth.com",
         org_id_to_org_member_info: {
             [orgMemberInfo.org_id]: orgMemberInfo,
         },
@@ -279,6 +297,7 @@ test("validateAuthHeaderAndGetUserWithOrgInfoWithExactRole works with requiredRo
     const orgMemberInfo = randomOrg()
     const internalUser: InternalUser = {
         user_id: uuid(),
+        email: "easteregg@propelauth.com",
         org_id_to_org_member_info: {
             [orgMemberInfo.org_id]: orgMemberInfo,
         },
@@ -313,6 +332,7 @@ test("validateAuthHeaderAndGetUserWithOrgInfoWithPermission works with permissio
     const orgMemberInfo = randomOrg()
     const internalUser: InternalUser = {
         user_id: uuid(),
+        email: "easteregg@propelauth.com",
         org_id_to_org_member_info: {
             [orgMemberInfo.org_id]: orgMemberInfo,
         },
@@ -347,6 +367,7 @@ test("validateAuthHeaderAndGetUserWithOrgInfoWithAllPermissions works with permi
     const orgMemberInfo = randomOrg()
     const internalUser: InternalUser = {
         user_id: uuid(),
+        email: "easteregg@propelauth.com",
         org_id_to_org_member_info: {
             [orgMemberInfo.org_id]: orgMemberInfo,
         },
@@ -420,6 +441,7 @@ function randomString() {
 function randomInternalUser(): InternalUser {
     return {
         user_id: uuid(),
+        email: "easteregg@propelauth.com",
         org_id_to_org_member_info: randomOrgIdToOrgMemberInfo(),
     }
 }


### PR DESCRIPTION
Add legacy user metadata to the User objects, including email, firstName, lastName, and username. These fields will be populated automatically from the incoming JWT.