### PR TITLE
new endpoints - api keys and org control

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -445,7 +445,7 @@ export function enableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string,
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/can_create_orgs/enable`, "PUT")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -464,7 +464,7 @@ export function disableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/can_create_orgs/disable`, "PUT")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -798,7 +798,7 @@ export function fetchApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: s
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -830,7 +830,7 @@ export function fetchCurrentApiKeys(authUrl: URL, integrationApiKey: string, api
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -854,7 +854,7 @@ export function fetchArchivedApiKeys(authUrl: URL, integrationApiKey: string, ap
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/archived?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -884,7 +884,7 @@ export function createApiKey(authUrl: URL, integrationApiKey: string, apiKeyCrea
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyCreateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -913,7 +913,7 @@ export function updateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "PATCH", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyUpdateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -932,7 +932,7 @@ export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyDeleteException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -945,19 +945,15 @@ export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: 
         })
 }
 
-export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string): Promise<ApiKeyValidation> {
-    if (!isValidHex(apiKeyId)) {
-        throw new ApiKeyValidateException("Invalid api key")
-    }
-
+export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKeyToken: string): Promise<ApiKeyValidation> {
     const request = {
-        api_key_token: apiKeyId,
+        api_key_token: apiKeyToken,
     }
 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/validate`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationintegrationApiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyValidateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import {httpRequest} from "./http"
-import {Org, User, UserMetadata} from "./user"
+import {ApiKeyFull, ApiKeyNew, ApiKeyResultPage, ApiKeyValidation, Org, User, UserMetadata} from "./user"
 import {
     CreateUserException,
     UpdateUserMetadataException,
@@ -12,20 +12,24 @@ import {
     ChangeUserRoleInOrgException,
     RemoveUserFromOrgException,
     UpdateOrgException,
-    UserNotFoundException, AccessTokenCreationException
+    UserNotFoundException,
+    AccessTokenCreationException,
+    ApiKeyFetchException,
+    ApiKeyUpdateException,
+    ApiKeyDeleteException, ApiKeyValidateException, ApiKeyCreateException
 } from "./exceptions";
 
-export function fetchUserMetadataByUserIdWithIdCheck(authUrl: URL, apiKey: string, userId: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
+export function fetchUserMetadataByUserIdWithIdCheck(authUrl: URL, integrationApiKey: string, userId: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
     if (isValidId(userId)) {
-        return fetchUserMetadataByQuery(authUrl, apiKey, userId, {include_orgs: includeOrgs || false})
+        return fetchUserMetadataByQuery(authUrl, integrationApiKey, userId, {include_orgs: includeOrgs || false})
     } else {
         return Promise.resolve(null);
     }
 }
 
-export function fetchUserMetadataByQuery(authUrl: URL, apiKey: string, pathParam: string, query: any): Promise<UserMetadata | null> {
+export function fetchUserMetadataByQuery(authUrl: URL, integrationApiKey: string, pathParam: string, query: any): Promise<UserMetadata | null> {
     const queryString = formatQueryParameters(query)
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${pathParam}?${queryString}`, "GET").then((httpResponse) => {
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${pathParam}?${queryString}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("apiKey is incorrect")
         } else if (httpResponse.statusCode === 404) {
@@ -40,7 +44,7 @@ export function fetchUserMetadataByQuery(authUrl: URL, apiKey: string, pathParam
 
 export function fetchBatchUserMetadata(
     authUrl: URL,
-    apiKey: string,
+    integrationApiKey: string,
     type: string,
     values: string[],
     keyFunction: (x: UserMetadata) => string,
@@ -48,7 +52,7 @@ export function fetchBatchUserMetadata(
 ): Promise<{ [key: string]: UserMetadata }> {
     const queryString = includeOrgs ? formatQueryParameters({include_orgs: includeOrgs}) : ""
     const jsonBody = {[type]: values}
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${type}?${queryString}`, "POST", JSON.stringify(jsonBody)).then(
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${type}?${queryString}`, "POST", JSON.stringify(jsonBody)).then(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -69,12 +73,12 @@ export function fetchBatchUserMetadata(
     )
 }
 
-export function fetchOrg(authUrl: URL, apiKey: string, orgId: string): Promise<Org | null> {
+export function fetchOrg(authUrl: URL, integrationApiKey: string, orgId: string): Promise<Org | null> {
     if (!isValidId(orgId)) {
         return Promise.resolve(null);
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${orgId}`, "GET").then((httpResponse) => {
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("apiKey is incorrect")
         } else if (httpResponse.statusCode === 404) {
@@ -103,13 +107,13 @@ export type OrgQueryResponse = {
     hasMoreResults: boolean,
 }
 
-export function fetchOrgByQuery(authUrl: URL, apiKey: string, query: OrgQuery): Promise<OrgQueryResponse> {
+export function fetchOrgByQuery(authUrl: URL, integrationApiKey: string, query: OrgQuery): Promise<OrgQueryResponse> {
     const request = {
         page_size: query.pageSize,
         page_number: query.pageNumber,
         order_by: query.orderBy,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/query`, "GET", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/query`, "GET", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -124,6 +128,8 @@ export function fetchOrgByQuery(authUrl: URL, apiKey: string, query: OrgQuery): 
             return JSON.parse(httpResponse.response, function (key, value) {
                 if (key === "org_id") {
                     this.orgId = value
+                } else if (key === "max_users") {
+                        this.max_users = value
                 } else if (key === "total_orgs") {
                     this.totalOrgs = value;
                 } else if (key === "current_page") {
@@ -155,7 +161,7 @@ export type UsersPagedResponse = {
     hasMoreResults: boolean
 }
 
-export function fetchUsersByQuery(authUrl: URL, apiKey: string, query: UsersQuery): Promise<UsersPagedResponse> {
+export function fetchUsersByQuery(authUrl: URL, integrationApiKey: string, query: UsersQuery): Promise<UsersPagedResponse> {
     const queryParams = {
         page_size: query.pageSize,
         page_number: query.pageNumber,
@@ -164,7 +170,7 @@ export function fetchUsersByQuery(authUrl: URL, apiKey: string, query: UsersQuer
         include_orgs: query.includeOrgs,
     }
     const q = formatQueryParameters(queryParams)
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/query?${q}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/query?${q}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -185,7 +191,7 @@ export type UsersInOrgQuery = {
     includeOrgs?: boolean,
 }
 
-export function fetchUsersInOrg(authUrl: URL, apiKey: string, query: UsersInOrgQuery): Promise<UsersPagedResponse> {
+export function fetchUsersInOrg(authUrl: URL, integrationApiKey: string, query: UsersInOrgQuery): Promise<UsersPagedResponse> {
     if (!isValidId(query.orgId)) {
         const emptyResponse: UsersPagedResponse = {
             users: [],
@@ -203,7 +209,7 @@ export function fetchUsersInOrg(authUrl: URL, apiKey: string, query: UsersInOrgQ
         include_orgs: query.includeOrgs,
     }
     const queryString = formatQueryParameters(queryParams)
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/org/${query.orgId}?${queryString}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/org/${query.orgId}?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -230,7 +236,7 @@ export type CreateUserRequest = {
     lastName?: string,
 }
 
-export function createUser(authUrl: URL, apiKey: string, createUserRequest: CreateUserRequest): Promise<User> {
+export function createUser(authUrl: URL, integrationApiKey: string, createUserRequest: CreateUserRequest): Promise<User> {
     const request = {
         email: createUserRequest.email,
         email_confirmed: createUserRequest.emailConfirmed,
@@ -243,7 +249,7 @@ export function createUser(authUrl: URL, apiKey: string, createUserRequest: Crea
         first_name: createUserRequest.firstName,
         last_name: createUserRequest.lastName,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -265,7 +271,7 @@ export type UpdateUserMetadataRequest = {
     metadata?: {[key: string]: any }
 }
 
-export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
+export function updateUserMetadata(authUrl: URL, integrationApiKey: string, userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
@@ -277,7 +283,7 @@ export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string,
         picture_url: updateUserMetadataRequest.pictureUrl,
         metadata: updateUserMetadataRequest.metadata,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}`, "PUT", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -293,12 +299,12 @@ export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string,
         })
 }
 
-export function deleteUser(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function deleteUser(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}`, "DELETE")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -312,12 +318,12 @@ export function deleteUser(authUrl: URL, apiKey: string, userId: string): Promis
         })
 }
 
-export function disableUser(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function disableUser(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/disable`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/disable`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -331,12 +337,12 @@ export function disableUser(authUrl: URL, apiKey: string, userId: string): Promi
         })
 }
 
-export function enableUser(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function enableUser(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/enable`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/enable`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -350,12 +356,12 @@ export function enableUser(authUrl: URL, apiKey: string, userId: string): Promis
         })
 }
 
-export function disableUser2fa(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function disableUser2fa(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/disable_2fa`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/disable_2fa`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -374,7 +380,7 @@ export type UpdateUserEmailRequest = {
     requireEmailConfirmation: boolean,
 }
 
-export function updateUserEmail(authUrl: URL, apiKey: string, userId: string, updateUserEmail: UpdateUserEmailRequest): Promise<boolean> {
+export function updateUserEmail(authUrl: URL, integrationApiKey: string, userId: string, updateUserEmail: UpdateUserEmailRequest): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
@@ -383,7 +389,7 @@ export function updateUserEmail(authUrl: URL, apiKey: string, userId: string, up
         new_email: updateUserEmail.newEmail,
         require_email_confirmation: updateUserEmail.requireEmailConfirmation,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/email`, "PUT", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/email`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -404,7 +410,7 @@ export type UpdateUserPasswordRequest = {
     askUserToUpdatePasswordOnLogin?: boolean,
 }
 
-export function updateUserPassword(authUrl: URL, apiKey: string, userId: string, updateUserPasswordRequest: UpdateUserPasswordRequest): Promise<boolean> {
+export function updateUserPassword(authUrl: URL, integrationApiKey: string, userId: string, updateUserPasswordRequest: UpdateUserPasswordRequest): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
@@ -413,7 +419,7 @@ export function updateUserPassword(authUrl: URL, apiKey: string, userId: string,
         password: updateUserPasswordRequest.password,
         ask_user_to_update_password_on_login: updateUserPasswordRequest.askUserToUpdatePasswordOnLogin,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/password`, "PUT", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/password`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -423,6 +429,44 @@ export function updateUserPassword(authUrl: URL, apiKey: string, userId: string,
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
                 throw new Error("Unknown error when updating password")
+            }
+
+            return true
+        })
+}
+
+export function enableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
+    if (!isValidId(userId)) {
+        return Promise.resolve(false)
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/can_create_orgs/enable`, "PUT")
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 404) {
+                return false
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when enabling canCreateOrgs")
+            }
+
+            return true
+        })
+}
+
+export function disableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
+    if (!isValidId(userId)) {
+        return Promise.resolve(false)
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/can_create_orgs/disable`, "PUT")
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 404) {
+                return false
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when disabling canCreateOrgs")
             }
 
             return true
@@ -440,14 +484,14 @@ export type MagicLink = {
     url: string
 }
 
-export function createMagicLink(authUrl: URL, apiKey: string, createMagicLinkRequest: CreateMagicLinkRequest): Promise<MagicLink> {
+export function createMagicLink(authUrl: URL, integrationApiKey: string, createMagicLinkRequest: CreateMagicLinkRequest): Promise<MagicLink> {
     const request = {
         email: createMagicLinkRequest.email,
         redirect_to_url: createMagicLinkRequest.redirectToUrl,
         expires_in_hours: createMagicLinkRequest.expiresInHours,
         create_new_user_if_one_doesnt_exist: createMagicLinkRequest.createNewUserIfOneDoesntExist,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/magic_link`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/magic_link`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -470,7 +514,7 @@ export type AccessToken = {
     access_token: string
 }
 
-export function createAccessToken(authUrl: URL, apiKey: string, createAccessTokenRequest: CreateAccessTokenRequest): Promise<AccessToken> {
+export function createAccessToken(authUrl: URL, integrationApiKey: string, createAccessTokenRequest: CreateAccessTokenRequest): Promise<AccessToken> {
     if (!isValidId(createAccessTokenRequest.userId)) {
         throw new UserNotFoundException()
     }
@@ -479,7 +523,7 @@ export function createAccessToken(authUrl: URL, apiKey: string, createAccessToke
         user_id: createAccessTokenRequest.userId,
         duration_in_minutes: createAccessTokenRequest.durationInMinutes,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/access_token`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/access_token`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -514,7 +558,7 @@ export type MigrateUserFromExternalSourceRequest = {
 }
 
 export function migrateUserFromExternalSource(authUrl: URL,
-                                              apiKey: string,
+                                              integrationApiKey: string,
                                               migrateUserFromExternalSourceRequest: MigrateUserFromExternalSourceRequest): Promise<User> {
     const request = {
         email: migrateUserFromExternalSourceRequest.email,
@@ -531,7 +575,7 @@ export function migrateUserFromExternalSource(authUrl: URL,
         last_name: migrateUserFromExternalSourceRequest.lastName,
         username: migrateUserFromExternalSourceRequest.username,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/migrate_user/`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/migrate_user/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -546,14 +590,15 @@ export function migrateUserFromExternalSource(authUrl: URL,
 }
 
 export type CreateOrgRequest = {
-    name: string
+    name: string,
+    max_users?: number,
 }
 
-export function createOrg(authUrl: URL, apiKey: string, createOrgRequest: CreateOrgRequest): Promise<Org> {
+export function createOrg(authUrl: URL, integrationApiKey: string, createOrgRequest: CreateOrgRequest): Promise<Org> {
     const request = {
         name: createOrgRequest.name,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -573,13 +618,13 @@ export type AddUserToOrgRequest = {
     role: string
 }
 
-export function addUserToOrg(authUrl: URL, apiKey: string, addUserToOrgRequest: AddUserToOrgRequest): Promise<boolean> {
+export function addUserToOrg(authUrl: URL, integrationApiKey: string, addUserToOrgRequest: AddUserToOrgRequest): Promise<boolean> {
     const request = {
         user_id: addUserToOrgRequest.userId,
         org_id: addUserToOrgRequest.orgId,
         role: addUserToOrgRequest.role,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/add_user`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/add_user`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -601,13 +646,13 @@ export type ChangeUserRoleInOrgRequest = {
     role: string
 }
 
-export function changeUserRoleInOrg(authUrl: URL, apiKey: string, changeUserRoleInOrgRequest: ChangeUserRoleInOrgRequest): Promise<boolean> {
+export function changeUserRoleInOrg(authUrl: URL, integrationApiKey: string, changeUserRoleInOrgRequest: ChangeUserRoleInOrgRequest): Promise<boolean> {
     const request = {
         user_id: changeUserRoleInOrgRequest.userId,
         org_id: changeUserRoleInOrgRequest.orgId,
         role: changeUserRoleInOrgRequest.role,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/change_role`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/change_role`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -628,12 +673,12 @@ export type RemoveUserFromOrgRequest = {
     orgId: string
 }
 
-export function removeUserFromOrg(authUrl: URL, apiKey: string, removeUserFromOrgRequest: RemoveUserFromOrgRequest): Promise<boolean> {
+export function removeUserFromOrg(authUrl: URL, integrationApiKey: string, removeUserFromOrgRequest: RemoveUserFromOrgRequest): Promise<boolean> {
     const request = {
         user_id: removeUserFromOrgRequest.userId,
         org_id: removeUserFromOrgRequest.orgId,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/remove_user`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/remove_user`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -653,10 +698,11 @@ export type UpdateOrgRequest = {
     orgId: string
     name?: string
     canSetupSaml?: boolean
+    max_users?: number
     metadata: {[key: string]: any},
 }
 
-export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
+export function updateOrg(authUrl: URL, integrationApiKey: string, updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
     if (!isValidId(updateOrgRequest.orgId)) {
         return Promise.resolve(false)
     }
@@ -666,7 +712,7 @@ export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: Update
         can_setup_saml: updateOrgRequest.canSetupSaml,
         metadata: updateOrgRequest.metadata,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${updateOrgRequest.orgId}`, "PUT", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${updateOrgRequest.orgId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -682,12 +728,12 @@ export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: Update
         })
 }
 
-export function deleteOrg(authUrl: URL, apiKey: string, orgId: string): Promise<boolean> {
+export function deleteOrg(authUrl: URL, integrationApiKey: string, orgId: string): Promise<boolean> {
     if (!isValidId(orgId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${orgId}`, "DELETE")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -702,12 +748,12 @@ export function deleteOrg(authUrl: URL, apiKey: string, orgId: string): Promise<
 }
 
 
-export function allowOrgToSetupSamlConnection(authUrl: URL, apiKey: string, orgId: string): Promise<boolean> {
+export function allowOrgToSetupSamlConnection(authUrl: URL, integrationApiKey: string, orgId: string): Promise<boolean> {
     if (!isValidId(orgId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${orgId}/allow_saml`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}/allow_saml`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -721,12 +767,12 @@ export function allowOrgToSetupSamlConnection(authUrl: URL, apiKey: string, orgI
         })
 }
 
-export function disallowOrgToSetupSamlConnection(authUrl: URL, apiKey: string, orgId: string): Promise<boolean> {
+export function disallowOrgToSetupSamlConnection(authUrl: URL, integrationApiKey: string, orgId: string): Promise<boolean> {
     if (!isValidId(orgId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${orgId}/disallow_saml`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}/disallow_saml`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("apiKey is incorrect")
@@ -740,11 +786,193 @@ export function disallowOrgToSetupSamlConnection(authUrl: URL, apiKey: string, o
         })
 }
 
+// functions for managing end user api keys
+
+export function fetchApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string): Promise<ApiKeyFull> {
+    if (!isValidHex(apiKeyId)) {
+        throw new ApiKeyFetchException("Invalid api key")
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "GET")
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 400) {
+                throw new ApiKeyFetchException(httpResponse.response)
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when creating the end user api key")
+            }
+
+            return parseEndUserApiKey(httpResponse.response)
+        })
+}
+
+export type ApiKeysQueryRequest = {
+    orgId?: string
+    userId?: string
+    userEmail?: string
+    pageSize?: number
+    pageNumber?: number
+}
+
+export function fetchCurrentApiKeys(authUrl: URL, integrationApiKey: string, apiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
+    const request = {
+        org_id: apiKeyQuery.orgId,
+        user_id: apiKeyQuery.userId,
+        user_email: apiKeyQuery.userEmail,
+        page_size: apiKeyQuery.pageSize,
+        page_number: apiKeyQuery.pageNumber,
+    }
+    const queryString = formatQueryParameters(request)
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys?${queryString}`, "GET")
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 400) {
+                throw new ApiKeyFetchException(httpResponse.response)
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when creating the end user api key")
+            }
+
+            return parseEndUserApiKey(httpResponse.response)
+        })
+}
+
+export function fetchArchivedApiKeys(authUrl: URL, integrationApiKey: string, apiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
+    const request = {
+        org_id: apiKeyQuery.orgId,
+        user_id: apiKeyQuery.userId,
+        user_email: apiKeyQuery.userEmail,
+        page_size: apiKeyQuery.pageSize,
+        page_number: apiKeyQuery.pageNumber,
+    }
+    const queryString = formatQueryParameters(request)
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/archived?${queryString}`, "GET")
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 400) {
+                throw new ApiKeyFetchException(httpResponse.response)
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when creating the end user api key")
+            }
+
+            return parseEndUserApiKey(httpResponse.response)
+        })
+}
+
+
+export type ApiKeysCreateRequest = {
+    orgId?: string
+    userId?: string
+    expiresAtSeconds?: number
+    metadata?: object
+}
+export function createApiKey(authUrl: URL, integrationApiKey: string, apiKeyCreate: ApiKeysCreateRequest): Promise<ApiKeyNew> {
+    const request = {
+        org_id: apiKeyCreate.orgId,
+        user_id: apiKeyCreate.userId,
+        expires_at_seconds: apiKeyCreate.expiresAtSeconds,
+        metadata: apiKeyCreate.metadata,
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys`, "POST", JSON.stringify(request))
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 400) {
+                throw new ApiKeyCreateException(httpResponse.response)
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when creating the end user api key")
+            }
+
+            return parseEndUserApiKey(httpResponse.response)
+        })
+}
+
+export type ApiKeyUpdateRequest = {
+    expiresAtSeconds?: number
+    metadata?: string
+}
+export function updateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string, apiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
+    if (!isValidHex(apiKeyId)) {
+        throw new ApiKeyUpdateException("Invalid api key")
+    }
+
+    const request = {
+        expires_at_seconds: apiKeyUpdate.expiresAtSeconds,
+        metadata: apiKeyUpdate.metadata,
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "PATCH", JSON.stringify(request))
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 400) {
+                throw new ApiKeyUpdateException(httpResponse.response)
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when updating the end user api key")
+            }
+
+            return true
+        })
+}
+
+export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string): Promise<boolean> {
+    if (!isValidHex(apiKeyId)) {
+        throw new ApiKeyDeleteException("Invalid api key")
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "DELETE")
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 400) {
+                throw new ApiKeyDeleteException(httpResponse.response)
+            } else if (httpResponse.statusCode === 404) {
+                return false
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when deleting the end user api key")
+            }
+
+            return true
+        })
+}
+
+export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string): Promise<ApiKeyValidation> {
+    if (!isValidHex(apiKeyId)) {
+        throw new ApiKeyValidateException("Invalid api key")
+    }
+
+    const request = {
+        api_key_token: apiKeyId,
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/validate`, "POST", JSON.stringify(request))
+        .then((httpResponse) => {
+            if (httpResponse.statusCode === 401) {
+                throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 400) {
+                throw new ApiKeyValidateException(httpResponse.response)
+            } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+                throw new Error("Unknown error when updating the end user api key")
+            }
+
+            return parseEndUserApiKey(httpResponse.response)
+        })
+}
 
 const idRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+const hexRegex = /^[0-9a-fA-F]{32}$/i;
 
 function isValidId(id: string): boolean {
     return idRegex.test(id)
+}
+
+function isValidHex(id: string): boolean {
+    return hexRegex.test(id)
 }
 
 function formatQueryParameters(obj: { [key: string]: any }): string {
@@ -763,10 +991,17 @@ function formatIssuer(authUrl: URL): string {
 
 function parseOrg(response: string): Org {
     const jsonParse = JSON.parse(response)
-    return {
+
+    let org: Org = {
         orgId: jsonParse.org_id,
         name: jsonParse.name,
     }
+
+    if (jsonParse.max_users) {
+        org.maxUsers = jsonParse.max_users
+    }
+
+    return org
 }
 
 function parseUser(response: string) {
@@ -827,6 +1062,44 @@ function parseUserMetadataAndOptionalPagingInfo(response: string) {
             this.hasMoreResults = value;
         } else if (key === "has_password") {
             this.hasPassword = value;
+        } else {
+            return value
+        }
+    });
+}
+
+function parseEndUserApiKey(response: string) {
+    return JSON.parse(response, function (key, value) {
+        if (key === "api_key_id") {
+            this.apiKeyId = value;
+        } else if (key === "api_key_token") {
+            this.apiKeyToken = value;
+        } else if (key === "created_at") {
+            this.createdAt = value;
+        } else if (key === "expires_at_seconds") {
+            this.expiresAtSeconds = value;
+        } else if (key === "metadata") {
+            this.metadata = value;
+        } else if (key === "user_id") {
+            this.userId = value;
+        } else if (key === "org_id") {
+            this.orgId = value;
+        } else if (key === "api_keys") {
+            this.apiKeys = value;
+        } else if (key === "total_api_keys") {
+            this.totalApiKeys = value;
+        } else if (key === "current_page") {
+            this.currentPage = value;
+        } else if (key === "page_size") {
+            this.pageSize = value;
+        } else if (key === "has_more_results") {
+            this.hasMoreResults = value;
+        } else if (key === "user_metadata") {
+            this.userMetadata = value;
+        } else if (key === "org_metadata") {
+            this.orgMetadata = value;
+        } else if (key === "user_role_in_org") {
+            this.userRoleInOrg = value;
         } else {
             return value
         }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,22 +1,24 @@
 import {httpRequest} from "./http"
 import {ApiKeyFull, ApiKeyNew, ApiKeyResultPage, ApiKeyValidation, Org, User, UserMetadata} from "./user"
 import {
-    CreateUserException,
-    UpdateUserMetadataException,
-    UpdateUserEmailException,
-    MagicLinkCreationException,
-    MigrateUserException,
-    CreateOrgException,
-    AddUserToOrgException,
-    UpdateUserPasswordException,
-    ChangeUserRoleInOrgException,
-    RemoveUserFromOrgException,
-    UpdateOrgException,
-    UserNotFoundException,
     AccessTokenCreationException,
+    AddUserToOrgException,
+    ApiKeyCreateException,
+    ApiKeyDeleteException,
     ApiKeyFetchException,
     ApiKeyUpdateException,
-    ApiKeyDeleteException, ApiKeyValidateException, ApiKeyCreateException
+    ApiKeyValidateException,
+    ChangeUserRoleInOrgException,
+    CreateOrgException,
+    CreateUserException,
+    MagicLinkCreationException,
+    MigrateUserException,
+    RemoveUserFromOrgException,
+    UpdateOrgException,
+    UpdateUserEmailException,
+    UpdateUserMetadataException,
+    UpdateUserPasswordException,
+    UserNotFoundException
 } from "./exceptions";
 
 export function fetchUserMetadataByUserIdWithIdCheck(authUrl: URL, integrationApiKey: string, userId: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
@@ -31,7 +33,7 @@ export function fetchUserMetadataByQuery(authUrl: URL, integrationApiKey: string
     const queryString = formatQueryParameters(query)
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${pathParam}?${queryString}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
-            throw new Error("apiKey is incorrect")
+            throw new Error("integrationApiKey is incorrect")
         } else if (httpResponse.statusCode === 404) {
             return null
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -55,7 +57,7 @@ export function fetchBatchUserMetadata(
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${type}?${queryString}`, "POST", JSON.stringify(jsonBody)).then(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Bad request " + httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -80,7 +82,7 @@ export function fetchOrg(authUrl: URL, integrationApiKey: string, orgId: string)
 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
-            throw new Error("apiKey is incorrect")
+            throw new Error("integrationApiKey is incorrect")
         } else if (httpResponse.statusCode === 404) {
             return null
         } else if (httpResponse.statusCode === 426) {
@@ -116,7 +118,7 @@ export function fetchOrgByQuery(authUrl: URL, integrationApiKey: string, query: 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/query`, "GET", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Invalid query " + httpResponse.response)
             } else if (httpResponse.statusCode === 426) {
@@ -129,7 +131,7 @@ export function fetchOrgByQuery(authUrl: URL, integrationApiKey: string, query: 
                 if (key === "org_id") {
                     this.orgId = value
                 } else if (key === "max_users") {
-                        this.max_users = value
+                    this.max_users = value
                 } else if (key === "total_orgs") {
                     this.totalOrgs = value;
                 } else if (key === "current_page") {
@@ -173,7 +175,7 @@ export function fetchUsersByQuery(authUrl: URL, integrationApiKey: string, query
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/query?${q}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Invalid query " + httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -212,7 +214,7 @@ export function fetchUsersInOrg(authUrl: URL, integrationApiKey: string, query: 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/org/${query.orgId}?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Invalid query " + httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -252,7 +254,7 @@ export function createUser(authUrl: URL, integrationApiKey: string, createUserRe
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new CreateUserException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -268,7 +270,7 @@ export type UpdateUserMetadataRequest = {
     firstName?: string,
     lastName?: string,
     pictureUrl?: string
-    metadata?: {[key: string]: any }
+    metadata?: { [key: string]: any }
 }
 
 export function updateUserMetadata(authUrl: URL, integrationApiKey: string, userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
@@ -286,7 +288,7 @@ export function updateUserMetadata(authUrl: URL, integrationApiKey: string, user
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateUserMetadataException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -307,7 +309,7 @@ export function deleteUser(authUrl: URL, integrationApiKey: string, userId: stri
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -326,7 +328,7 @@ export function disableUser(authUrl: URL, integrationApiKey: string, userId: str
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/disable`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -345,7 +347,7 @@ export function enableUser(authUrl: URL, integrationApiKey: string, userId: stri
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/enable`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -364,7 +366,7 @@ export function disableUser2fa(authUrl: URL, integrationApiKey: string, userId: 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/disable_2fa`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -392,7 +394,7 @@ export function updateUserEmail(authUrl: URL, integrationApiKey: string, userId:
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/email`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateUserEmailException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -422,7 +424,7 @@ export function updateUserPassword(authUrl: URL, integrationApiKey: string, user
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/password`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateUserPasswordException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -443,7 +445,7 @@ export function enableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string,
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/can_create_orgs/enable`, "PUT")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -462,7 +464,7 @@ export function disableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/can_create_orgs/disable`, "PUT")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -494,7 +496,7 @@ export function createMagicLink(authUrl: URL, integrationApiKey: string, createM
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/magic_link`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new MagicLinkCreationException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -526,7 +528,7 @@ export function createAccessToken(authUrl: URL, integrationApiKey: string, creat
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/access_token`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new AccessTokenCreationException(httpResponse.response)
             } else if (httpResponse.statusCode === 403) {
@@ -578,7 +580,7 @@ export function migrateUserFromExternalSource(authUrl: URL,
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/migrate_user/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new MigrateUserException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -601,7 +603,7 @@ export function createOrg(authUrl: URL, integrationApiKey: string, createOrgRequ
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new CreateOrgException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -627,7 +629,7 @@ export function addUserToOrg(authUrl: URL, integrationApiKey: string, addUserToO
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/add_user`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new AddUserToOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -655,7 +657,7 @@ export function changeUserRoleInOrg(authUrl: URL, integrationApiKey: string, cha
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/change_role`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ChangeUserRoleInOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -681,7 +683,7 @@ export function removeUserFromOrg(authUrl: URL, integrationApiKey: string, remov
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/remove_user`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new RemoveUserFromOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -699,7 +701,7 @@ export type UpdateOrgRequest = {
     name?: string
     canSetupSaml?: boolean
     max_users?: number
-    metadata: {[key: string]: any},
+    metadata: { [key: string]: any },
 }
 
 export function updateOrg(authUrl: URL, integrationApiKey: string, updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
@@ -715,7 +717,7 @@ export function updateOrg(authUrl: URL, integrationApiKey: string, updateOrgRequ
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${updateOrgRequest.orgId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -736,7 +738,7 @@ export function deleteOrg(authUrl: URL, integrationApiKey: string, orgId: string
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -756,7 +758,7 @@ export function allowOrgToSetupSamlConnection(authUrl: URL, integrationApiKey: s
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}/allow_saml`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -775,7 +777,7 @@ export function disallowOrgToSetupSamlConnection(authUrl: URL, integrationApiKey
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}/disallow_saml`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -796,7 +798,7 @@ export function fetchApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: s
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -828,7 +830,7 @@ export function fetchCurrentApiKeys(authUrl: URL, integrationApiKey: string, api
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -852,7 +854,7 @@ export function fetchArchivedApiKeys(authUrl: URL, integrationApiKey: string, ap
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/archived?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -870,6 +872,7 @@ export type ApiKeysCreateRequest = {
     expiresAtSeconds?: number
     metadata?: object
 }
+
 export function createApiKey(authUrl: URL, integrationApiKey: string, apiKeyCreate: ApiKeysCreateRequest): Promise<ApiKeyNew> {
     const request = {
         org_id: apiKeyCreate.orgId,
@@ -881,7 +884,7 @@ export function createApiKey(authUrl: URL, integrationApiKey: string, apiKeyCrea
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyCreateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -896,6 +899,7 @@ export type ApiKeyUpdateRequest = {
     expiresAtSeconds?: number
     metadata?: string
 }
+
 export function updateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string, apiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
     if (!isValidHex(apiKeyId)) {
         throw new ApiKeyUpdateException("Invalid api key")
@@ -909,7 +913,7 @@ export function updateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "PATCH", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyUpdateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -928,7 +932,7 @@ export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyDeleteException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -953,7 +957,7 @@ export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/validate`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("integrationApiKey is incorrect")
+                throw new Error("integrationintegrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyValidateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,21 +3,33 @@ import {
     addUserToOrg,
     AddUserToOrgRequest,
     allowOrgToSetupSamlConnection,
+    ApiKeysCreateRequest,
+    ApiKeysQueryRequest,
+    ApiKeyUpdateRequest,
     changeUserRoleInOrg,
-    ChangeUserRoleInOrgRequest, createAccessToken, CreateAccessTokenRequest,
+    ChangeUserRoleInOrgRequest,
+    createAccessToken,
+    CreateAccessTokenRequest,
+    createApiKey,
     createMagicLink,
     CreateMagicLinkRequest,
     createOrg,
     CreateOrgRequest,
     createUser,
     CreateUserRequest,
+    deleteApiKey,
     deleteOrg,
     deleteUser,
     disableUser,
     disableUser2fa,
+    disableUserCanCreateOrgs,
     disallowOrgToSetupSamlConnection,
     enableUser,
+    enableUserCanCreateOrgs,
+    fetchApiKey,
+    fetchArchivedApiKeys,
     fetchBatchUserMetadata,
+    fetchCurrentApiKeys,
     fetchOrg,
     fetchOrgByQuery,
     fetchUserMetadataByQuery,
@@ -31,6 +43,7 @@ import {
     OrgQueryResponse,
     removeUserFromOrg,
     RemoveUserFromOrgRequest,
+    updateApiKey,
     updateOrg,
     UpdateOrgRequest,
     updateUserEmail,
@@ -42,9 +55,14 @@ import {
     UsersInOrgQuery,
     UsersPagedResponse,
     UsersQuery,
+    validateApiKey,
 } from "./api"
 import {ForbiddenException, UnauthorizedException} from "./exceptions"
 import {
+    ApiKeyFull,
+    ApiKeyNew,
+    ApiKeyResultPage,
+    ApiKeyValidation,
     InternalUser,
     Org,
     OrgIdToOrgMemberInfo,
@@ -66,7 +84,7 @@ export type AuthOptions = {
 
 export function initAuth(opts: AuthOptions) {
     const authUrl: URL = validateAuthUrl(opts.authUrl)
-    const apiKey: string = opts.apiKey
+    const integrationApiKey: string = opts.apiKey
     const publicKeyPromise = jose.importSPKI(opts.verifierKey, 'RS256')
 
     const validateAuthHeaderAndGetUser = wrapValidateAuthorizationHeaderAndGetUser(publicKeyPromise, authUrl.origin)
@@ -77,125 +95,162 @@ export function initAuth(opts: AuthOptions) {
     const validateAuthHeaderAndGetUserWithOrgInfoWithAllPermissions = wrapValidateAccessTokenAndGetUserWithOrgInfoWithAllPermissions(publicKeyPromise, authUrl.origin)
 
     function fetchUserMetadataByUserId(userId: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
-        return fetchUserMetadataByUserIdWithIdCheck(authUrl, apiKey, userId, includeOrgs);
+        return fetchUserMetadataByUserIdWithIdCheck(authUrl, integrationApiKey, userId, includeOrgs);
     }
 
     function fetchUserMetadataByEmail(email: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
-        return fetchUserMetadataByQuery(authUrl, apiKey, "email", {
+        return fetchUserMetadataByQuery(authUrl, integrationApiKey, "email", {
             email: email,
             include_orgs: includeOrgs || false
         })
     }
 
     function fetchUserMetadataByUsername(username: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
-        return fetchUserMetadataByQuery(authUrl, apiKey, "username", {
+        return fetchUserMetadataByQuery(authUrl, integrationApiKey, "username", {
             username: username,
             include_orgs: includeOrgs || false
         })
     }
 
     function fetchBatchUserMetadataByUserIds(userIds: string[], includeOrgs?: boolean): Promise<{ [userId: string]: UserMetadata }> {
-        return fetchBatchUserMetadata(authUrl, apiKey, "user_ids", userIds, (x) => x.userId, includeOrgs || false)
+        return fetchBatchUserMetadata(authUrl, integrationApiKey, "user_ids", userIds, (x) => x.userId, includeOrgs || false)
     }
 
     function fetchBatchUserMetadataByEmails(emails: string[], includeOrgs?: boolean): Promise<{ [email: string]: UserMetadata }> {
-        return fetchBatchUserMetadata(authUrl, apiKey, "emails", emails, (x) => x.email, includeOrgs || false)
+        return fetchBatchUserMetadata(authUrl, integrationApiKey, "emails", emails, (x) => x.email, includeOrgs || false)
     }
 
     function fetchBatchUserMetadataByUsernames(usernames: string[], includeOrgs?: boolean): Promise<{ [username: string]: UserMetadata }> {
-        return fetchBatchUserMetadata(authUrl, apiKey, "usernames", usernames, (x) => x.username || "", includeOrgs || false)
+        return fetchBatchUserMetadata(authUrl, integrationApiKey, "usernames", usernames, (x) => x.username || "", includeOrgs || false)
     }
 
     function fetchOrgWrapper(orgId: string): Promise<Org | null> {
-        return fetchOrg(authUrl, apiKey, orgId)
+        return fetchOrg(authUrl, integrationApiKey, orgId)
     }
 
     function fetchOrgsByQueryWrapper(orgQuery: OrgQuery): Promise<OrgQueryResponse> {
-        return fetchOrgByQuery(authUrl, apiKey, orgQuery)
+        return fetchOrgByQuery(authUrl, integrationApiKey, orgQuery)
     }
 
     function fetchUsersByQueryWrapper(usersQuery: UsersQuery): Promise<UsersPagedResponse> {
-        return fetchUsersByQuery(authUrl, apiKey, usersQuery)
+        return fetchUsersByQuery(authUrl, integrationApiKey, usersQuery)
     }
 
     function fetchUsersInOrgWrapper(usersInOrgQuery: UsersInOrgQuery): Promise<UsersPagedResponse> {
-        return fetchUsersInOrg(authUrl, apiKey, usersInOrgQuery)
+        return fetchUsersInOrg(authUrl, integrationApiKey, usersInOrgQuery)
     }
 
     function createUserWrapper(createUserRequest: CreateUserRequest): Promise<User> {
-        return createUser(authUrl, apiKey, createUserRequest)
+        return createUser(authUrl, integrationApiKey, createUserRequest)
     }
 
     function updateUserMetadataWrapper(userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
-        return updateUserMetadata(authUrl, apiKey, userId, updateUserMetadataRequest)
+        return updateUserMetadata(authUrl, integrationApiKey, userId, updateUserMetadataRequest)
     }
 
     function deleteUserWrapper(userId: string): Promise<boolean> {
-        return deleteUser(authUrl, apiKey, userId)
+        return deleteUser(authUrl, integrationApiKey, userId)
     }
 
     function disableUserWrapper(userId: string): Promise<boolean> {
-        return disableUser(authUrl, apiKey, userId)
+        return disableUser(authUrl, integrationApiKey, userId)
     }
 
     function enableUserWrapper(userId: string): Promise<boolean> {
-        return enableUser(authUrl, apiKey, userId)
+        return enableUser(authUrl, integrationApiKey, userId)
     }
 
     function disableUser2faWrapper(userId: string): Promise<boolean> {
-        return disableUser2fa(authUrl, apiKey, userId)
+        return disableUser2fa(authUrl, integrationApiKey, userId)
     }
 
     function updateUserEmailWrapper(userId: string, updateUserEmailRequest: UpdateUserEmailRequest): Promise<boolean> {
-        return updateUserEmail(authUrl, apiKey, userId, updateUserEmailRequest)
+        return updateUserEmail(authUrl, integrationApiKey, userId, updateUserEmailRequest)
     }
 
     function updateUserPasswordWrapper(userId: string, updateUserPasswordRequest: UpdateUserPasswordRequest): Promise<boolean> {
-        return updateUserPassword(authUrl, apiKey, userId, updateUserPasswordRequest)
+        return updateUserPassword(authUrl, integrationApiKey, userId, updateUserPasswordRequest)
+    }
+
+    function enableUserCanCreateOrgsWrapper(userId: string): Promise<boolean> {
+        return enableUserCanCreateOrgs(authUrl, integrationApiKey, userId)
+    }
+
+    function disableUserCanCreateOrgsWrapper(userId: string): Promise<boolean> {
+        return disableUserCanCreateOrgs(authUrl, integrationApiKey, userId)
     }
 
     function createMagicLinkWrapper(createMagicLinkRequest: CreateMagicLinkRequest): Promise<MagicLink> {
-        return createMagicLink(authUrl, apiKey, createMagicLinkRequest)
+        return createMagicLink(authUrl, integrationApiKey, createMagicLinkRequest)
     }
 
     function createAccessTokenWrapper(createAccessTokenRequest: CreateAccessTokenRequest): Promise<AccessToken> {
-        return createAccessToken(authUrl, apiKey, createAccessTokenRequest)
+        return createAccessToken(authUrl, integrationApiKey, createAccessTokenRequest)
     }
 
     function migrateUserFromExternalSourceWrapper(migrateUserFromExternalSourceRequest: MigrateUserFromExternalSourceRequest): Promise<User> {
-        return migrateUserFromExternalSource(authUrl, apiKey, migrateUserFromExternalSourceRequest)
+        return migrateUserFromExternalSource(authUrl, integrationApiKey, migrateUserFromExternalSourceRequest)
     }
 
     function createOrgWrapper(createOrgRequest: CreateOrgRequest): Promise<Org> {
-        return createOrg(authUrl, apiKey, createOrgRequest)
+        return createOrg(authUrl, integrationApiKey, createOrgRequest)
     }
 
     function addUserToOrgWrapper(addUserToOrgRequest: AddUserToOrgRequest): Promise<boolean> {
-        return addUserToOrg(authUrl, apiKey, addUserToOrgRequest)
+        return addUserToOrg(authUrl, integrationApiKey, addUserToOrgRequest)
     }
 
     function changeUserRoleInOrgWrapper(changeUserRoleInOrgRequest: ChangeUserRoleInOrgRequest): Promise<boolean> {
-        return changeUserRoleInOrg(authUrl, apiKey, changeUserRoleInOrgRequest)
+        return changeUserRoleInOrg(authUrl, integrationApiKey, changeUserRoleInOrgRequest)
     }
 
     function removeUserFromOrgWrapper(removeUserFromOrgRequest: RemoveUserFromOrgRequest): Promise<boolean> {
-        return removeUserFromOrg(authUrl, apiKey, removeUserFromOrgRequest)
+        return removeUserFromOrg(authUrl, integrationApiKey, removeUserFromOrgRequest)
     }
 
     function updateOrgWrapper(updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
-        return updateOrg(authUrl, apiKey, updateOrgRequest)
+        return updateOrg(authUrl, integrationApiKey, updateOrgRequest)
     }
 
     function deleteOrgWrapper(orgId: string): Promise<boolean> {
-        return deleteOrg(authUrl, apiKey, orgId)
+        return deleteOrg(authUrl, integrationApiKey, orgId)
     }
 
     function allowOrgToSetupSamlConnectionWrapper(orgId: string): Promise<boolean> {
-        return allowOrgToSetupSamlConnection(authUrl, apiKey, orgId)
+        return allowOrgToSetupSamlConnection(authUrl, integrationApiKey, orgId)
     }
 
     function disallowOrgToSetupSamlConnectionWrapper(orgId: string): Promise<boolean> {
-        return disallowOrgToSetupSamlConnection(authUrl, apiKey, orgId)
+        return disallowOrgToSetupSamlConnection(authUrl, integrationApiKey, orgId)
+    }
+
+    // end user api key wrappers
+    function fetchApiKeyWrapper(apiKeyId: string): Promise<ApiKeyFull> {
+        return fetchApiKey(authUrl, integrationApiKey, apiKeyId)
+    }
+
+    function fetchCurrentApiKeysWrapper(apiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
+        return fetchCurrentApiKeys(authUrl, integrationApiKey, apiKeyQuery)
+    }
+
+    function fetchArchivedApiKeysWrapper(apiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
+        return fetchArchivedApiKeys(authUrl, integrationApiKey, apiKeyQuery)
+    }
+
+    function createApiKeyWrapper(apiKeyCreate: ApiKeysCreateRequest): Promise<ApiKeyNew> {
+        return createApiKey(authUrl, integrationApiKey, apiKeyCreate)
+    }
+
+    function updateApiKeyWrapper(apiKeyId: string, apiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
+        return updateApiKey(authUrl, integrationApiKey, apiKeyId, apiKeyUpdate)
+    }
+
+    function deleteApiKeyWrapper(apiKeyId: string): Promise<boolean> {
+        return deleteApiKey(authUrl, integrationApiKey, apiKeyId)
+    }
+
+    function validateApiKeyWrapper(apiKeyId: string): Promise<ApiKeyValidation> {
+        return validateApiKey(authUrl, integrationApiKey, apiKeyId)
     }
 
     return {
@@ -223,12 +278,14 @@ export function initAuth(opts: AuthOptions) {
         updateUserEmail: updateUserEmailWrapper,
         updateUserPassword: updateUserPasswordWrapper,
         createMagicLink: createMagicLinkWrapper,
+        createAccessToken: createAccessTokenWrapper,
         migrateUserFromExternalSource: migrateUserFromExternalSourceWrapper,
         deleteUser: deleteUserWrapper,
         disableUser: disableUserWrapper,
         enableUser: enableUserWrapper,
         disableUser2fa: disableUser2faWrapper,
-
+        enableUserCanCreateOrgs: enableUserCanCreateOrgsWrapper,
+        disableUserCanCreateOrgs: disableUserCanCreateOrgsWrapper,
         // org management functions
         createOrg: createOrgWrapper,
         addUserToOrg: addUserToOrgWrapper,
@@ -238,6 +295,14 @@ export function initAuth(opts: AuthOptions) {
         deleteOrg: deleteOrgWrapper,
         allowOrgToSetupSamlConnection: allowOrgToSetupSamlConnectionWrapper,
         disallowOrgToSetupSamlConnection: disallowOrgToSetupSamlConnectionWrapper,
+        // api keys functions
+        fetchApiKey: fetchApiKeyWrapper,
+        fetchCurrentApiKeys: fetchCurrentApiKeysWrapper,
+        fetchArchivedApiKeys: fetchArchivedApiKeysWrapper,
+        createApiKey: createApiKeyWrapper,
+        updateApiKey: updateApiKeyWrapper,
+        deleteApiKey: deleteApiKeyWrapper,
+        validateApiKey: validateApiKeyWrapper,
     }
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -249,8 +249,8 @@ export function initAuth(opts: AuthOptions) {
         return deleteApiKey(authUrl, integrationApiKey, apiKeyId)
     }
 
-    function validateApiKeyWrapper(apiKeyId: string): Promise<ApiKeyValidation> {
-        return validateApiKey(authUrl, integrationApiKey, apiKeyId)
+    function validateApiKeyWrapper(apiKeyToken: string): Promise<ApiKeyValidation> {
+        return validateApiKey(authUrl, integrationApiKey, apiKeyToken)
     }
 
     return {

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -128,6 +128,46 @@ export class UpdateUserMetadataException extends Error {
     }
 }
 
+export class ApiKeyValidateException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
+export class ApiKeyDeleteException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
+export class ApiKeyUpdateException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
+export class ApiKeyCreateException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
+export class ApiKeyFetchException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
 export class UserNotFoundException extends Error {
 }
 

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -128,6 +128,9 @@ export class UpdateUserMetadataException extends Error {
     }
 }
 
+export class UserNotFoundException extends Error {
+}
+
 export class ApiKeyValidateException extends Error {
     readonly fieldToErrors: {[fieldName: string]: string[]};
     constructor(message: string) {
@@ -167,7 +170,3 @@ export class ApiKeyFetchException extends Error {
         this.fieldToErrors = JSON.parse(message);
     }
 }
-
-export class UserNotFoundException extends Error {
-}
-

--- a/src/user.ts
+++ b/src/user.ts
@@ -18,6 +18,7 @@ export type User = {
 export type Org = {
     orgId: string,
     name: string,
+    maxUsers?: number,
 }
 
 export type UserMetadata = {
@@ -34,6 +35,7 @@ export type UserMetadata = {
     locked: boolean,
     enabled: boolean,
     mfaEnabled: boolean,
+    canCreateOrgs: boolean,
 
     createdAt: number,
     lastActiveAt: number,
@@ -174,4 +176,33 @@ export function toOrgIdToOrgMemberInfo(snake_case?: {
     }
 
     return camelCase
+}
+
+export type ApiKeyNew ={
+    apiKeyId: string
+    apiKeyToken: string
+}
+
+export type ApiKeyFull = {
+    apiKeyId: string
+    createdAt: number
+    expiresAtSeconds: number
+    metadata: {[key: string]: any}
+    userId: string
+    orgId: string
+}
+
+export type ApiKeyResultPage = {
+    apiKeys: ApiKeyFull[]
+    totalApiKeys: number
+    currentPage: number
+    pageSize: number
+    hasMoreResults: boolean
+}
+
+export type ApiKeyValidation = {
+    metadata?: { [key: string]: any }
+    userMetadata?: { [key: string]: any }
+    orgMetadata?: { [key: string]: any }
+    userRoleInOrg?: string
 }


### PR DESCRIPTION
## Set the maximum users in an org

Set the maximum number of users an org can have with the new **max_users** property on the Org object. Set it with the usual updateOrg() function, and see the current value with fetchOrg(). It's an optional field, and if it's missing orgs will continue to allow unlimited users.

## Let only certain users create orgs

Users can be given permission to create orgs through **enableUserCanCreateOrgs**, and that permission can be removed with **disableUserCanCreateOrgs**. This special permission overrides the realm-wide users_can_create_orgs. With this new functionality, you can turn off org creation in general, and only grant certain users the privilege. (If the realm-wide users_can_create_orgs is on, then everyone will always be able to create orgs.)

## API Keys

A whole host of functions for managing API Keys. These aren't the Integration API Keys you use to communicate with PropelAuth (in this very library), these are API Keys that you can give out to your own clients. We'll happily manage them for you. You can set the optional user, an optional org, optional metadata, and an expiration.

These new API Key endpoints are:

- **fetchApiKey**
- **fetchCurrentApiKeys**
- **fetchArchivedApiKeys**
- **createApiKey**
- **updateApiKey**
- **deleteApiKey**
- **validateApiKey**