### PR TITLE
add main field in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propelauth/cloudflare-worker",
-  "version": "v2.0.7",
+  "version": "v2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@propelauth/cloudflare-worker",
-      "version": "v2.0.7",
+      "version": "v2.1.3",
       "license": "MIT",
       "dependencies": {
         "jose": "^4.11.2"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/PropelAuth/cloudflare-worker"
   },
-  "version": "v2.1.2",
+  "version": "v2.1.3",
   "license": "MIT",
   "keywords": [
     "auth",
@@ -39,6 +39,7 @@
     "prepublishOnly": "npm run build"
   },
   "module": "dist/index.mjs",
+  "main": "dist/index.mjs",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
I was getting the following error when using this package in a Vite project (Nuxt 3)
```bash
Cannot find package '/@propelauth/cloudflare-worker/' imported from /nuxt-todo/.nuxt/dev/index.mjs

  at __node_internal_captureLargerStackTrace (node:internal/errors:496:5)
  at new NodeError (node:internal/errors:405:5)
  at legacyMainResolve (node:internal/modules/esm/resolve:192:9)
  at packageResolve (node:internal/modules/esm/resolve:768:14)
  at moduleResolve (node:internal/modules/esm/resolve:830:20)
  at defaultResolve (node:internal/modules/esm/resolve:1035:11)
  at DefaultModuleLoader.resolve (node:internal/modules/esm/loader:269:12)
  at DefaultModuleLoader.getModuleJob (node:internal/modules/esm/loader:153:32)
  at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:33)
  at link (node:internal/modules/esm/module_job:75:36)
```

Adding the `main` field into the package.json file allowed Vite to import the package. [Node module docs](https://nodejs.org/api/packages.html#package-entry-points) indicate `exports` field is preferred, but since the package is a single `dist/index.mjs` file it should work just as well.